### PR TITLE
fix: Bug verbose log path

### DIFF
--- a/templates/backuputils.cm.yaml
+++ b/templates/backuputils.cm.yaml
@@ -16,7 +16,7 @@ data:
 
     #GHE_RESTORE_HOST="github-standby.example.com"
     #GHE_RESTORE_SKIP_AUDIT_LOGS=no
-    GHE_VERBOSE_LOG="/data/log/backup-verbose.log"
+    GHE_VERBOSE_LOG="{{ .Values.backupUtils.backupConfig.verboseLogFile }}"
     GHE_EXTRA_SSH_OPTS="{{ .Values.backupUtils.backupConfig.extraCommandOptions }}"
     #GHE_EXTRA_RSYNC_OPTS=""
     

--- a/values.yaml
+++ b/values.yaml
@@ -25,6 +25,9 @@ backupUtils:
     # Maximum number of snapshots to keep
     snapshotRententionNumber: 72
 
+    # Absolute path where detailed backup logs are stored
+    verboseLogFile: "/data/backup-verbose.log"
+
     # Extra SSH options for backup-utils pod to connect to GHE instances
     # We usually recommend not to modify the default value for stability reasons
     extraCommandOptions: "-i /ghe-ssh/id_ed25519 -o UserKnownHostsFile=/ghe-ssh/known_hosts"


### PR DESCRIPTION
Log creation fails because there is no log directory by default under the data path.